### PR TITLE
Automatically import etc.linux.memoryerror

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -1,7 +1,15 @@
 import std;
 import repld;
 
+version (linux) import etc.linux.memoryerror;
+
 void main() {
+    version (linux)
+    {
+        bool registered = registerMemoryErrorHandler();
+        scope (exit)
+            if (registered) deregisterMemoryErrorHandler();
+    }
     auto runner = new REPLRunner();
     bool shouldExit = false;
     runner["exit"] = { shouldExit = true; };

--- a/source/app.d
+++ b/source/app.d
@@ -4,8 +4,7 @@ import repld;
 version (linux) import etc.linux.memoryerror;
 
 void main() {
-    version (linux)
-    {
+    version (linux) {
         bool registered = registerMemoryErrorHandler();
         scope (exit)
             if (registered) deregisterMemoryErrorHandler();


### PR DESCRIPTION
Using memoryErrorHandler helps to debug memory errors on linux.